### PR TITLE
chore: bump google/cloud-pubsub

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "queue-interop/queue-interop": "^0.8",
-        "google/cloud-pubsub": "^2.0",
+        "google/cloud-pubsub": "^1.51|^2.0",
         "enqueue/dsn": "^0.10"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "queue-interop/queue-interop": "^0.8",
-        "google/cloud-pubsub": "^1.4.3",
+        "google/cloud-pubsub": "^2.0",
         "enqueue/dsn": "^0.10"
     },
     "require-dev": {


### PR DESCRIPTION
# Bump google/cloud-pubsub version 

## Description
This PR bump google/cloud-pubsub
<img width="329" alt="Screenshot 2025-03-28 at 12 17 16" src="https://github.com/user-attachments/assets/6814b27d-8cfa-4969-992f-b91dade9ac85" />

